### PR TITLE
Fix Flag redirecting to hackclub.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
     <h2 style="margin-block-start: 0em; margin-block-end: 0em;">The Hack Club Map</h2>
     <p style="margin-block-start: 0.4em; margin-block-end: 0em;">To be added message <b href="https://hackclub.slack.com/team/U041FQB8VK2">@thomas</b> on Slack.</p>
   </div>
-  <a class="flag" href="https://hackclub.com/" alt="Hack Club"></a>
+  <div class="flag" alt="Hack Club"></div>
   <club-map></club-map>
 </body>
 </html>


### PR DESCRIPTION
Fixes [hackclub/toolbox#49](https://github.com/hackclub/toolbox/issues/49). This PR makes the Hack Club Flag not a link, as the map is only used in the toolbox background, where links should not work.