### PR TITLE
Change Airbridge to ClubAPI

### DIFF
--- a/club-map.js
+++ b/club-map.js
@@ -31,7 +31,7 @@ const onConnected = (host) => {
 
   (async () => {
     let clubs = await fetch(
-      `https://api2.hackclub.com/v0.1/Club%20Map/Clubs`
+      `https://clubapi.hackclub.com/clubs/map`
     ).then((res) => res.json());
     clubs.forEach(({ fields: x }) => {
       if (!x.club_status || x.club_status !== "Active") return;


### PR DESCRIPTION
I'm adding a way to opt out of the club map

Airbridge does not support filtering records, so to filter out opted out clubs we need to use the Club API. The https://clubapi.hackclub.com/clubs/map route is exactly identical except for filtering out opted out clubs